### PR TITLE
Add attributes to the span

### DIFF
--- a/examples/span.c
+++ b/examples/span.c
@@ -45,6 +45,8 @@ int main() {
   nrt_attributes_set_string(attrs, "string", "value");
   nrt_attributes_set_bool(attrs, "bool", true);
   nrt_span_set_attributes(span, &attrs);
+  assert(NULL == attrs);
+
   nrt_span_destroy(&span);
   assert(NULL == span);
 

--- a/examples/trace_api.c
+++ b/examples/trace_api.c
@@ -59,6 +59,7 @@ int main() {
     nrt_attributes_set_string(attrs, "string", "value");
     nrt_attributes_set_bool(attrs, "bool", true);
     nrt_span_set_attributes(span, &attrs);
+    assert(NULL == attrs);
 
     nrt_span_batch_record(batch, &span);
     assert(NULL == span);

--- a/include/newrelic-telemetry-sdk.h
+++ b/include/newrelic-telemetry-sdk.h
@@ -227,7 +227,10 @@ bool nrt_span_set_duration(nrt_span_t* span, nrt_time_t duration);
 /**
  * Set attributes on a span
  *
- * If successful, the span gets a copy of the attributes.
+ * If the attributes were successfully added to the span, the span takes
+ * ownership of the attribute collection. Otherwise the attribute collection
+ * will be destroyed. The passed pointer to the attribute collection will
+ * always be set to NULL.
  *
  * @param span
  * @param attributes a collection of attributes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,11 +387,11 @@ pub extern "C" fn nrt_span_set_attributes(
 ) -> bool {
     if let Some(attr) = unsafe { attributes.as_mut() } {
         if let Some(span) = unsafe { span.as_mut() } {
-            if !attr.is_null() {
-                let attr = unsafe { Box::from_raw(*attr) };
+            if let Some(attr) = unsafe { attr.as_mut() } {
                 for (key, value) in attr.iter() {
                     span.set_attribute(key, value.clone());
                 }
+                nrt_attributes_destroy(attributes);
                 return true;
             }
         }


### PR DESCRIPTION
This PR completes the span wrapping functionality in #17 by adding attributes to the span. `nrt_span_set_attributes()` copies over the attributes into the `span.attributes` hashmap (Which may or may not already have the [optional span fields](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/capabilities.md#spans) added). 

CI run [here](https://github.com/Fahmy-Mohammed/newrelic-telemetry-sdk-c/pull/2/checks)