### PR TITLE
Enable submodule scanning by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/vendor/newrelic-telemetry-sdk-rust" # Location of submodule
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This is an alternative to #28. It will cause dependabot to scan the submodule and open PRs to automatically update it.