### PR TITLE
Dependabot: Test known issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["staticlib", "cdylib"]
 newrelic-telemetry = { path = "vendor/newrelic-telemetry-sdk-rust", features = ["blocking"] }
 log = "0.4.11"
 simplelog = "0.8.0"
+rand = "0.6.1"


### PR DESCRIPTION
This PR introduces an issue we know dependabot will flag. This is being done to see if the warning about submodules interferes with the reporting of other issues in the project.