### PR TITLE
Dependabot: Ignore local submodule dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ version: 2
 updates:
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
+    ignore:
+      - dependency-name: "newrelic-telemetry"
     schedule:
       interval: "daily"
   - package-ecosystem: "gitsubmodule"


### PR DESCRIPTION
This PR attempts to [ignore](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#ignore) the Rust SDK dependency since the error scanning it causes no results to be found by dependabot.