### PR TITLE
Dependabot: Remove ignore path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
-    ignore:
-      - dependency-name: "newrelic-telemetry"
     schedule:
       interval: "daily"
   - package-ecosystem: "gitsubmodule"


### PR DESCRIPTION
This PR removes the attempt made in #32 since dependabot needs to be able to resolve all dependencies in order for it to work. It isn't possible to ignore unresolvable dependencies.

From their [docs](https://docs.github.com/en/github/administering-a-repository/about-github-dependabot-version-updates#supported-repositories-and-ecosystems):
> Currently, GitHub Dependabot version updates doesn't support manifest or lock files that contain any private git dependencies or private git registries. This is because, when running version updates, Dependabot must be able to resolve all dependencies from their source to verify that version updates have been successful.

While the above is in reference to private deps, it doesn't appear that dependabot supports dependencies that can only be resolved by checking out a git submodule (at least the error message doesn't give any indication that it does). Our submodule is currently private so that might be why it isn't working now.

Either way, it doesn't make sense to leave this ignore option in.