### PR TITLE
Adds support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ For general querying information, see:
 - [Query New Relic data](https://docs.newrelic.com/docs/query-your-data/explore-query-data/explore-data/introduction-querying-new-relic-data)
 - [Intro to NRQL](https://docs.newrelic.com/docs/query-your-data/nrql-new-relic-query-language/get-started/introduction-nrql-new-relics-query-language)
 
+## Support
+
+New Relic hosts and moderates an online forum where customers can interact with
+New Relic employees as well as other customers to get help and share best
+practices. Like all official New Relic open source projects, there's a related
+Community topic in the New Relic Explorers Hub. You can find this project's
+topic/threads in the [Telemetry SDK section of Explorers Hub](https://discuss.newrelic.com/t/new-relic-c-telemetry-sdk/114557)
+
 ## Contributing
 
 We encourage your contributions to improve the C Telemetry SDK! Keep in mind
@@ -157,13 +165,6 @@ click-through using CLA-Assistant. You only have to sign the CLA one time per
 project. If you have any questions, or to execute our corporate CLA, required
 if your contribution is on behalf of a company,  please drop us an email at
 opensource@newrelic.com.
-
-## Support
-New Relic hosts and moderates an online forum where customers can interact with
-New Relic employees as well as other customers to get help and share best
-practices. Like all official New Relic open source projects, there's a related
-Community topic in the New Relic Explorers Hub. You can find this project's
-topic/threads in the [Telemetry SDK section of Explorers Hub](https://discuss.newrelic.com/t/new-relic-c-telemetry-sdk-open-source/114557)
 
 ## License
 


### PR DESCRIPTION
Adds a support section to the readme which points the user to an explorers hub post. This will allow the user to post questions in the explorer's hub community without needing to open an issue for it in Github. The post on explorers hub still needs a bit of editing but I will do that as soon as we get ownership permissions as a team. That should be done within the next day or so. 