### PR TITLE
fix valgrind examples workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
 
     - name: install dependencies
       run: |
+          sudo apt-get update
           sudo apt-get install valgrind
 
     - name: run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
       with:
-          token: ${{ secrets.NEWRELIC_PAT }}
           submodules: recursive
 
     - name: install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
       with:
-          token: ${{ secrets.NEWRELIC_PAT }}
           submodules: recursive
 
     - name: run tests


### PR DESCRIPTION
The `Valgrind examples` CI workflow is having issues pulling in the `Valgrind` package. This PR fixes that.