### PR TITLE
Use Ubuntu 20.04 on doc generation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+            sudo apt-get update
             sudo apt-get install -y doxygen
 
       - name: Build Documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
         with:
-            token: ${{ secrets.NEWRELIC_PAT }}
             submodules: recursive
 
       - name: Install Dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   api_docs:
       name: Build Api Documentation
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The `ubuntu-latest` image used in the `docs.yml` workflow resolves to Ubuntu 18.04.  Our Doxygen setup was developed on a far more recent version of Doxygen which is satisfied by Ubuntu 20.04.

Unfortunately there is no perfect way to fully test this prior to merge, but a test example, with the only issue being one SVG badge (which I'm assuming is related to Firefox security settings) can be viewed at my personal site linked in team chat.