### PR TITLE
update api documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cmake --build .
 
 In order to send telemetry data to New Relic APIs, you will need an Insert API key. to find out how to generate this key, see our [docs](https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys).
 
-Refer to the [API documentation](include/newrelic-telemetry-sdk.h) and to the
+Refer to the [API documentation](https://newrelic.github.io/newrelic-telemetry-sdk-c/) and to the
 [examples](examples).
 
 This is a simple application that sends a single span:


### PR DESCRIPTION
This updates the API documentation link in the README to point to the Doxygen generated API Docs.