### PR TITLE
Manually install Doxygen 1.8.20 and dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,14 @@ jobs:
 
       - name: Install Dependencies
         run: |
-            sudo apt-get update
-            sudo apt-get install -y doxygen
-
+          sudo apt-get update
+          sudo apt-get install libclang-9-dev
+          wget http://doxygen.nl/files/doxygen-1.8.20.linux.bin.tar.gz
+          tar -xzf doxygen-1.8.20.linux.bin.tar.gz
+          mkdir -p "$HOME/bin"
+          cp doxygen-1.8.20/bin/doxygen "$HOME/bin/doxygen"
+          rm -rf doxygen-1.8.20.linux.bin.tar.gz doxygen-1.8.20
       - name: Build Documentation
         run: |
-            ./tools/update-api-documentation.bash main
-            exit 0
+          PATH="$HOME/bin":$PATH ./tools/update-api-documentation.bash main
+          exit 0


### PR DESCRIPTION
With Ubuntu 20.04 added in #40, we can update Doxygen to the exact version the documentation was developed on (1.8.20).  This fixes some slight formatting and linking issues.